### PR TITLE
Fix OutcomesData schema

### DIFF
--- a/api.json
+++ b/api.json
@@ -1150,9 +1150,14 @@
         ]
       },
       "OutcomesData": {
-        "type": "array",
-        "items": {
-          "$ref": "#/components/schemas/OutcomeData"
+        "type": "object",
+        "properties":{
+          "outcomes": {
+            "type":"array",
+            "items": {
+              "$ref": "#/components/schemas/OutcomeData"
+            }
+          }
         }
       },
       "Filter": {


### PR DESCRIPTION
Motivation: the OutcomesData schema did not match what is actually
returned from the API.