### PR TITLE
Fix response for get_apps 

### DIFF
--- a/api.json
+++ b/api.json
@@ -1716,7 +1716,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "string"
+                  "$ref": "#/components/schemas/Apps"
                 }
               }
             }


### PR DESCRIPTION
Update the response payload definition for get_apps to reference the already defined Apps model, rather than a JSON string.