### PR TITLE
Fix for incorrect return type for the get_apps method

### DIFF
--- a/api.json
+++ b/api.json
@@ -1716,10 +1716,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/App"
-                  }
+                  "$ref": "#/components/schemas/Apps"
                 }
               }
             }

--- a/api.json
+++ b/api.json
@@ -1716,7 +1716,10 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "string"
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/App"
+                  }
                 }
               }
             }


### PR DESCRIPTION
```swagger
 "/apps": {
      "get": {
        "operationId": "get_apps",
        "summary": "View apps",
        "description": "View the details of all of your current OneSignal apps",
        "responses": {
          "200": {
            "description": "OK",
            "content": {
              "application/json": {
                "schema": {
                  "type": "array",  <----------------------- this was "type": "string"
                  "items": {
                    "$ref": "#/components/schemas/App"
                  }
                }
              }
            }
          }
        },
```