### PR TITLE
Added name parameter to Notification model for SMS messages

### DIFF
--- a/api.json
+++ b/api.json
@@ -350,6 +350,11 @@
                 "type": "integer",
                 "readOnly": true
               },
+              "name": {
+                "type": "string",
+                "description": "Required for SMS Messages.\nAn identifier for tracking message within the OneSignal dashboard or export analytics.\nNot shown to end user.",
+                "writeOnly": true
+              },
               "aggregation": {
                 "type": "string",
                 "enum": [


### PR DESCRIPTION
Updated api.json to include `name` parameter to the Notification model since it is required for SMS delivery with API https://documentation.onesignal.com/reference/sms-channel-properties