### PR TITLE
Remove default: true from IsIos attribute to provide more optimal defaults

### DIFF
--- a/api.json
+++ b/api.json
@@ -365,7 +365,6 @@
               },
               "isIos": {
                 "type": "boolean",
-                "default": true,
                 "description": "Indicates whether to send to all devices registered under your app's Apple iOS platform.",
                 "writeOnly": true,
                 "nullable": true


### PR DESCRIPTION
Update the `IsIos` attribute in the `Notification` model to remove `default: true` in the spec.  By defaulting `IsIos` to true the create notification operation will create notifications that are limited to iOS devices, which is not a good default behavior.  By removing this, the default behavior is to now create a notification which has no device type filtering.