### PR TITLE
CreateNotificationSuccessResponse update

### DIFF
--- a/api.json
+++ b/api.json
@@ -308,7 +308,8 @@
                   "type": "string"
                 }
               }
-            }
+            },
+            "nullable": true
           },
           "target_channel": {
             "type": "string",
@@ -1914,11 +1915,7 @@
           "errors": {
             "$ref": "#/components/schemas/Notification200Errors"
           }
-        },
-        "required": [
-          "id",
-          "recipients"
-        ]
+        }
       },
       "CancelNotificationSuccessResponse": {
         "type": "object",


### PR DESCRIPTION
CreateNotificationSuccessResponse no loner requires 'id' and 'recipients' in the body.